### PR TITLE
Rework routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In this case that would be `GET` to `/`, if you visit it you get the response
 [
   {
     "method": "POST",
-    "path": "http://example.com/GreetService.HelloWorld",
+    "path": "http://example.com/HelloWorld"
   }
 ]
 ```

--- a/_example/main.go
+++ b/_example/main.go
@@ -39,17 +39,17 @@ func main() {
 	// The implementation is done in internal/greet/service.go
 	greetSvc := greet.NewService()
 	v1.Register(
-		// POST http://localhost:7777/api/v1/GreetService.HelloWorld
-		// the endpoint name is being reflected from the GreetService in api/v1/greet.go
+		// POST http://localhost:7777/api/v1/HelloWorld
+		// the endpoint path is reflected from function name.
 		ferry.Procedure(greetSvc.HelloWorld),
-		// POST http://localhost:7777/api/v1/GreetService.HelloName
+		// POST http://localhost:7777/api/v1/HelloName
 		// Content-Type: application/json
 		// { "name": "Joe" }
-		// the endpoint name is being reflected from the GreetService in api/v1/greet.go
+		// the endpoint path is reflected from function name.
 		ferry.Procedure(greetSvc.HelloName),
-		// GET http://localhost:7777/api/v1/GreetService.StreamGreetings
+		// GET http://localhost:7777/api/v1/StreamGreetings
 		// This will start streaming SSE events
-		// the endpoint name is being reflected from the GreetService in api/v1/greet.go
+		// the endpoint path is reflected from function name.
 		ferry.Stream(greetSvc.StreamGreetings),
 	)
 

--- a/handler.go
+++ b/handler.go
@@ -21,7 +21,7 @@ type Handler struct {
 }
 
 // specHandler builds http.HandlerFunc for the API spec.
-func specHandler(handlers []Handler) http.HandlerFunc {
+func specHandler(handlers map[string]Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		endpointURL := "http://"
 		if r.TLS != nil {

--- a/meta.go
+++ b/meta.go
@@ -1,7 +1,6 @@
 package ferry
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -10,30 +9,28 @@ import (
 
 // serviceMeta contains meta information for the service method.
 type serviceMeta struct {
-	serviceName string
-	methodName  string
-	body        map[string]string
-	query       map[string]string
+	reflectedName string
+	methodName    string
+	body          map[string]string
+	query         map[string]string
 }
 
 // path builds path for the service method.
-func (s serviceMeta) path() string { return "/" + s.serviceName + "." + s.methodName }
+func (s serviceMeta) path() string { return "/" + s.methodName }
 
 // buildMeta uses reflection to determine service name and method name.
 func buildMeta(function, request interface{}) (serviceMeta, error) {
 	name := runtime.FuncForPC(reflect.ValueOf(function).Pointer()).Name()
-	if !strings.HasSuffix(name, "-fm") {
-		return serviceMeta{}, errors.New("handler can only built from function with receiver")
-	}
 
+	// -fm is a suffix for functions that have receiver.
 	nameParts := strings.Split(strings.TrimSuffix(name, "-fm"), ".")
 	if len(nameParts) < 2 {
-		return serviceMeta{}, errors.New("handler can only built from function with receiver")
+		return serviceMeta{}, fmt.Errorf("can not use %q as handler", name)
 	}
 
 	meta := serviceMeta{
-		serviceName: strings.TrimPrefix(nameParts[len(nameParts)-2], "*"),
-		methodName:  nameParts[len(nameParts)-1],
+		reflectedName: name,
+		methodName:    nameParts[len(nameParts)-1],
 	}
 
 	var err error

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,0 +1,113 @@
+package ferry
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+type testMeta struct{}
+
+func (*testMeta) TestProcedure(ctx context.Context, _ *empty) (*empty, error) {
+	return &empty{}, nil
+}
+
+func testProc(ctx context.Context, _ *empty) (*empty, error) {
+	return &empty{}, nil
+}
+
+func TestBuildMeta(t *testing.T) {
+	t.Run("handles anonymous functions", func(t *testing.T) {
+		m, err := buildMeta(func(ctx context.Context, _ *empty) (*empty, error) {
+			return &empty{}, nil
+		}, empty{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := serviceMeta{
+			reflectedName: "github.com/damejeras/ferry.TestBuildMeta.func1.1",
+			methodName:    "1",
+			body:          make(map[string]string),
+			query:         make(map[string]string),
+		}
+
+		if !reflect.DeepEqual(m, expected) {
+			t.Errorf("got %+v", m)
+		}
+
+		m, err = buildMeta(func(ctx context.Context, _ *empty) (*empty, error) {
+			return &empty{}, nil
+		}, empty{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected = serviceMeta{
+			reflectedName: "github.com/damejeras/ferry.TestBuildMeta.func1.2",
+			methodName:    "2",
+			body:          make(map[string]string),
+			query:         make(map[string]string),
+		}
+
+		if !reflect.DeepEqual(m, expected) {
+			t.Errorf("got %+v", m)
+		}
+	})
+
+	t.Run("handles function with pointer receiver", func(t *testing.T) {
+		svc := new(testMeta)
+		m, err := buildMeta(svc.TestProcedure, empty{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := serviceMeta{
+			reflectedName: "github.com/damejeras/ferry.(*testMeta).TestProcedure-fm",
+			methodName:    "TestProcedure",
+			body:          make(map[string]string),
+			query:         make(map[string]string),
+		}
+
+		if !reflect.DeepEqual(m, expected) {
+			t.Errorf("got %+v", m)
+		}
+	})
+
+	t.Run("handles function with value receiver", func(t *testing.T) {
+		svc := testService{}
+		m, err := buildMeta(svc.StreamOneEvent, empty{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := serviceMeta{
+			reflectedName: "github.com/damejeras/ferry.testService.StreamOneEvent-fm",
+			methodName:    "StreamOneEvent",
+			body:          make(map[string]string),
+			query:         make(map[string]string),
+		}
+
+		if !reflect.DeepEqual(m, expected) {
+			t.Errorf("got %+v", m)
+		}
+	})
+
+	t.Run("handles function without receiver", func(t *testing.T) {
+		m, err := buildMeta(testProc, empty{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := serviceMeta{
+			reflectedName: "github.com/damejeras/ferry.testProc",
+			methodName:    "testProc",
+			body:          make(map[string]string),
+			query:         make(map[string]string),
+		}
+
+		if !reflect.DeepEqual(m, expected) {
+			t.Errorf("got %+v", m)
+		}
+	})
+}

--- a/procedure_test.go
+++ b/procedure_test.go
@@ -19,26 +19,13 @@ func (t testService) TestProcedureWithParams(ctx context.Context, r *jsonRequest
 }
 
 func TestProcedure(t *testing.T) {
-	t.Run("should panic if procedure function does not have receiver", func(t *testing.T) {
-		t.Parallel()
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-
-		Procedure(func(ctx context.Context, r *empty) (*empty, error) {
-			return &empty{}, nil
-		})
-	})
-
 	t.Run("returns response without request params", func(t *testing.T) {
 		t.Parallel()
 		router := NewRouter()
 		svc := testService{}
 		router.Register(Procedure(svc.TestProcedureWithoutParams))
 		rr := httptest.NewRecorder()
-		r := httptest.NewRequest("POST", "/testService.TestProcedureWithoutParams", nil)
+		r := httptest.NewRequest("POST", "/TestProcedureWithoutParams", nil)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		r = r.WithContext(ctx)
@@ -62,7 +49,7 @@ func TestProcedure(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		rr := httptest.NewRecorder()
-		r := httptest.NewRequest("POST", "/testService.TestProcedureWithParams", bytes.NewReader(payload))
+		r := httptest.NewRequest("POST", "/TestProcedureWithParams", bytes.NewReader(payload))
 		r.Header.Set("Content-Type", "application/json")
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
@@ -91,7 +78,7 @@ func TestProcedure(t *testing.T) {
 		svc := testService{}
 		router.Register(Procedure(svc.TestProcedureWithParams))
 		rr := httptest.NewRecorder()
-		r := httptest.NewRequest("POST", "/testService.TestProcedureWithParams", nil)
+		r := httptest.NewRequest("POST", "/TestProcedureWithParams", nil)
 		r.Header.Set("Content-Type", "application/json")
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()

--- a/router_test.go
+++ b/router_test.go
@@ -38,14 +38,14 @@ func TestRouter(t *testing.T) {
 		expected := `[
   {
     "method": "POST",
-    "path": "http://example.com/testService.TestProcedureWithParams",
+    "path": "http://example.com/TestProcedureWithParams",
     "body": {
       "value": "string"
     }
   },
   {
     "method": "GET",
-    "path": "http://example.com/testService.StreamOneEvent",
+    "path": "http://example.com/StreamOneEvent",
     "query": {
       "value": "string"
     }

--- a/stream_test.go
+++ b/stream_test.go
@@ -88,7 +88,7 @@ func TestStream(t *testing.T) {
 		router.Register(Stream(svc.EmptyStreamForSixSeconds))
 		rr := httptest.NewRecorder()
 
-		router.ServeHTTP(rr, httptest.NewRequest("GET", "/testService.EmptyStreamForSixSeconds", nil))
+		router.ServeHTTP(rr, httptest.NewRequest("GET", "/EmptyStreamForSixSeconds", nil))
 		if rr.Code != http.StatusOK {
 			t.Errorf("expected status code %d, got %d", http.StatusOK, rr.Code)
 		}
@@ -115,7 +115,7 @@ event: keep-alive
 		svc := testService{}
 		router.Register(Stream(svc.StreamForSixSeconds))
 		rr := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/testService.StreamForSixSeconds?value=test_data", nil)
+		r := httptest.NewRequest("GET", "/StreamForSixSeconds?value=test_data", nil)
 		// ctx, cancel := context.WithTimeout(context.Background(), time.Second*6)
 		// defer cancel()
 		// r = r.WithContext(ctx)
@@ -169,7 +169,7 @@ data: {"value":"test_data"}
 		svc := testService{}
 		router.Register(Stream(svc.LeakyStream))
 		rr := httptest.NewRecorder()
-		r := httptest.NewRequest("GET", "/testService.LeakyStream", nil)
+		r := httptest.NewRequest("GET", "/LeakyStream", nil)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		r = r.WithContext(ctx)
@@ -190,7 +190,7 @@ data: {"value":"test_data"}
 		router.Register(Stream(svc.StreamOneEvent))
 		rr := httptest.NewRecorder()
 
-		router.ServeHTTP(rr, httptest.NewRequest("GET", "/testService.StreamOneEvent?value=test", nil))
+		router.ServeHTTP(rr, httptest.NewRequest("GET", "/StreamOneEvent?value=test", nil))
 		if rr.Code != http.StatusOK {
 			t.Errorf("expected status code %d, got %d", http.StatusOK, rr.Code)
 		}


### PR DESCRIPTION
this would give more control on routing service methods. Now, each service can have its own router mounted to desired paths.